### PR TITLE
tree-wide: compat to current gyroidos wic-based build

### DIFF
--- a/conf/trustx/raspberrypi-generic.inc
+++ b/conf/trustx/raspberrypi-generic.inc
@@ -1,8 +1,11 @@
 INITRAMFS_IMAGE_BUNDLE = "1"
 INITRAMFS_IMAGE = "trustx-cml-initramfs"
 
-TRUSTME_FSTYPES = "trustmerpi"
-TRUSTME_PARTTABLE_TYPE="msdos"
+TRUSTME_FSTYPES = "wic wic.bmap"
+TRUSTME_BOOTPART_FS = "vfat"
+TRUSTME_PARTTABLE_TYPE = "msdos"
+
+TRUSTME_TARGET_ALIGN = "4096"
 
 TRUSTME_HARDWARE = "arm"
 TRUSTME_LOGTTY = "tty11"
@@ -10,16 +13,66 @@ TRUSTME_LOGTTY = "tty11"
 PACKAGE_CLASSES = "package_ipk"
 BBMULTICONFIG = "container"
 
-PREFERRED_PROVIDER_virtual/kernel ?= "linux-raspberrypi-dev"
+PREFERRED_PROVIDER_virtual/kernel:${MACHINE} ?= "linux-raspberrypi-dev"
 PREFERRED_PROVIDER_virtual/kernel:gyroidos-cml ?= "linux-raspberrypi-dev"
 #PREFERRED_VERSION_linux-raspberrypi = "5.15.%"
-LINUX_VERSION := "6.4.y"
-LINUX_RPI_BRANCH := "rpi-6.4.y"
+LINUX_VERSION := "6.12.y"
+LINUX_RPI_BRANCH := "rpi-6.12.y"
 
+# overwrite device tree with new locations in kernel v6.x
+RPI_KERNEL_DEVICETREE ?= " \
+    broadcom/bcm2708-rpi-zero.dtb \
+    broadcom/bcm2708-rpi-zero-w.dtb \
+    broadcom/bcm2708-rpi-b.dtb \
+    broadcom/bcm2708-rpi-b-rev1.dtb \
+    broadcom/bcm2708-rpi-b-plus.dtb \
+    broadcom/bcm2709-rpi-2-b.dtb \
+    broadcom/bcm2710-rpi-2-b.dtb \
+    broadcom/bcm2710-rpi-3-b.dtb \
+    broadcom/bcm2710-rpi-3-b-plus.dtb \
+    broadcom/bcm2710-rpi-zero-2.dtb \
+    broadcom/bcm2711-rpi-4-b.dtb \
+    broadcom/bcm2711-rpi-400.dtb \
+    broadcom/bcm2708-rpi-cm.dtb \
+    broadcom/bcm2710-rpi-cm3.dtb \
+    broadcom/bcm2711-rpi-cm4.dtb \
+    broadcom/bcm2711-rpi-cm4s.dtb \
+"
 
 RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/tpm-slb9670.dtbo"
 RPI_EXTRA_CONFIG = "dtoverlay=tpm-slb9670"
 ENABLE_SPI_BUS = "1"
 
-CMDLINE:append = " cgroup_enable=memory lsm=integrity"
+CMDLINE:append = " lsm=integrity"
 MACHINE_FEATURES:append = " armstub"
+
+def make_dtb_boot_files(d):
+    # Generate IMAGE_BOOT_FILES entries for device tree files listed in
+    # KERNEL_DEVICETREE.
+    alldtbs = d.getVar('KERNEL_DEVICETREE')
+
+    prefix = d.getVar('KERNEL_DEPLOYSUBDIR')
+    if prefix != "" :
+        prefix = prefix + "/"
+
+    def transform(dtb):
+        base = os.path.basename(dtb)
+        if dtb.endswith('dtbo') or base == 'overlay_map.dtb':
+            # overlay dtb:
+            # eg: overlays/hifiberry-amp.dtbo has:
+            #     DEPLOYDIR file: hifiberry-amp.dtbo
+            #     destination: overlays/hifiberry-amp.dtbo
+            return '{}{};{}'.format(prefix, base, dtb)
+        elif dtb.endswith('dtb'):
+            # eg: whatever/bcm2708-rpi-b.dtb has:
+            #     DEPLOYDIR file: bcm2708-rpi-b.dtb
+            #     destination: bcm2708-rpi-b.dtb
+            return '{}{};{}'.format(prefix, base, base)
+
+    return ' '.join([transform(dtb) for dtb in alldtbs.split(' ') if dtb])
+
+IMAGE_BOOT_FILES = "${BOOTFILES_DIR_NAME}/* \
+                 ${@make_dtb_boot_files(d)} \
+                 ${KERNEL_DEPLOYSUBDIR}/${KERNEL_IMAGETYPE_DIRECT}-initramfs-${MACHINE}.bin;${SDIMG_KERNELIMAGE}"
+
+WKS_FILE:${MACHINE} = "trustx-cml.raspberrypi.wks.in"

--- a/conf/trustx/raspberrypi2.inc
+++ b/conf/trustx/raspberrypi2.inc
@@ -1,4 +1,9 @@
 require raspberrypi-generic.inc
 
 MACHINE="raspberrypi2"
+MACHINEOVERRIDES =. "raspberrypi2:"
+
 TRUSTME_CONTAINER_ARCH = "qemuarm"
+
+# Kernel image name
+SDIMG_KERNELIMAGE = "kernel7.img"

--- a/conf/trustx/raspberrypi3-64.inc
+++ b/conf/trustx/raspberrypi3-64.inc
@@ -1,4 +1,10 @@
 require raspberrypi-generic.inc
 
 MACHINE="raspberrypi3-64"
+MACHINEOVERRIDES =. "raspberrypi3-64:"
+
 TRUSTME_CONTAINER_ARCH = "qemuarm64"
+
+# Kernel image name
+KERNEL_IMAGETYPE_DIRECT = "Image"
+SDIMG_KERNELIMAGE = "kernel8.img"

--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -1,1 +1,5 @@
-inherit trustmerpi
+KERNEL_IMAGE_FILE = "cml-kernel/${KERNEL_IMAGETYPE_DIRECT}-initramfs-${MACHINE}.bin"
+OS_CONFIG_IN := "${THISDIR}/${PN}/${OS_NAME}.conf"
+prepare_kernel_conf:append () {
+    sed -i "s|%%sdimg_name%%|${SDIMG_KERNELIMAGE}|" "${OS_CONFIG}"
+}

--- a/images/trustx-cml/kernel.conf
+++ b/images/trustx-cml/kernel.conf
@@ -1,0 +1,30 @@
+name: "kernel"
+hardware: "arm"
+version: 1
+mounts {
+	image_file: "kernel"
+	mount_point: "/boot/%%sdimg_name%%"
+	fs_type: "none"
+	mount_type: FLASH
+}
+mounts {
+	image_file: "modules"
+	mount_point: "/mnt/modules.img"
+	fs_type: "none"
+	mount_type: FLASH
+}
+mounts {
+	image_file: "firmware"
+	mount_point: "/mnt/firmware.img"
+	fs_type: "none"
+	mount_type: FLASH
+}
+mounts {
+	image_file: "device"
+	mount_point: "/data/cml/device.conf"
+	fs_type: "none"
+	mount_type: FLASH
+}
+description {
+        en: "fake OS for kernel update (arm) kernel+cml only. No bootfiles and device tree!"
+}

--- a/recipes-kernel/linux/linux-raspberrypi%.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi%.bbappend
@@ -3,5 +3,6 @@ require recipes-kernel/linux/linux-gyroidos.inc
 SRC_URI += "\
 	file://trustx-rpi.cfg \
 "
+LINUX_VERSION_EXTENSION = "-gyroidos"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-raspberrypi:"

--- a/wic/trustx-cml.raspberrypi.wks.in
+++ b/wic/trustx-cml.raspberrypi.wks.in
@@ -1,0 +1,4 @@
+part /boot --source bootimg-partition --fstype=${TRUSTME_BOOTPART_FS} --label boot --active --align 4096 --fixed-size ${TRUSTME_BOOTPART_SIZE}M
+part / --source rootfs  --fstype=${TRUSTME_DATAPART_FS} --label trustme --align ${TRUSTME_TARGET_ALIGN} --extra-space ${TRUSTME_DATAPART_EXTRA_SPACE}M
+
+bootloader --ptable ${TRUSTME_PARTTABLE_TYPE}


### PR DESCRIPTION
Introduced necessary changes to be compatible with current meta-trustx and used wic build. Further, we switch to current v6.12 branch of the raspberrypi kernel.

The cml update fakeOS is not complete yet. It just contains the kernel and CML but not the bootloader files and device tree files which are located in the boot partition.