### PR TITLE
RPi5 + Secure Boot

### DIFF
--- a/conf/gyroidos/raspberrypi-generic.inc
+++ b/conf/gyroidos/raspberrypi-generic.inc
@@ -77,3 +77,10 @@ IMAGE_BOOT_FILES = "${BOOTFILES_DIR_NAME}/* \
                  ${KERNEL_DEPLOYSUBDIR}/${KERNEL_IMAGETYPE_DIRECT}-initramfs-${MACHINE}.bin;${SDIMG_KERNELIMAGE}"
 
 WKS_FILE:${MACHINE} = "gyroidos-cml.raspberrypi.wks.in"
+
+# Secure Boot (RPi4 + RPi5 only)
+# RPi with stock eeprom does not boot from the boot.img for secure boot
+# disable secure boot build by default
+RPI_SECURE_BOOT ?= "0"
+PKI_KEY_SIZE = "${@oe.utils.vartrue('RPI_SECURE_BOOT', '2048', '4096', d)}"
+RPI_WIC_BOOT_PLUGIN = "${@oe.utils.vartrue('RPI_SECURE_BOOT', 'bootimg-partition-rpi-sb', 'bootimg-partition', d)}"

--- a/conf/gyroidos/raspberrypi5.inc
+++ b/conf/gyroidos/raspberrypi5.inc
@@ -1,0 +1,16 @@
+require raspberrypi-generic.inc
+
+MACHINE="raspberrypi5"
+MACHINEOVERRIDES =. "raspberrypi5:"
+
+GYROIDOS_CONTAINER_ARCH = "qemuarm64"
+
+# currently not included by meta-raspberrypi
+RPI_KERNEL_DEVICETREE:append = " broadcom/bcm2712-rpi-500.dtb"
+
+# if SERIAL_CONSOLES is set and ENABLE_UART is false, getty will flood
+# the LOGTTY with error messages. Clear SERIAL_CONSOLES to silence errors.
+python () {
+    if not d.getVar('ENABLE_UART', True) or d.getVar('ENABLE_UART', True) == "0":
+        d.setVar('SERIAL_CONSOLES', "")
+}

--- a/images/gyroidos-cml-initramfs.bbappend
+++ b/images/gyroidos-cml-initramfs.bbappend
@@ -1,0 +1,4 @@
+# HACK: the boot.img for RPi secure boot must not be larger than 180 MB.
+# remove the openssh server from the CML to reduce initramfs size in dev builds
+PACKAGE_INSTALL:remove = "${@oe.utils.vartrue('RPI_SECURE_BOOT', 'openssh-sshd', '', d)}"
+PACKAGE_INSTALL:remove = "${@oe.utils.vartrue('RPI_SECURE_BOOT', 'ssh-keys', '', d)}"

--- a/images/gyroidos-cml.bbappend
+++ b/images/gyroidos-cml.bbappend
@@ -3,3 +3,8 @@ OS_CONFIG_IN := "${THISDIR}/${PN}/${OS_NAME}.conf"
 prepare_kernel_conf:append () {
     sed -i "s|%%sdimg_name%%|${SDIMG_KERNELIMAGE}|" "${OS_CONFIG}"
 }
+
+DEPENDS:append:raspberrypi4-64 = " rpi-eeprom-native"
+WICVARS:append:raspberrypi4-64 = " SECURE_BOOT_SIG_KEY"
+DEPENDS:append:raspberrypi5 = " rpi-eeprom-native"
+WICVARS:append:raspberrypi5 = " SECURE_BOOT_SIG_KEY"

--- a/images/rpi-eeprom-secure-boot-image.bb
+++ b/images/rpi-eeprom-secure-boot-image.bb
@@ -1,0 +1,56 @@
+DESCRIPTION = "Helper image to deploy secure boot key on RPi 4 + RPi 5"
+LICENSE = "MIT & Apache-2.0"
+
+inherit image
+
+DEPENDS += "dosfstools-native mtools-native rpi-eeprom-native openssl-native"
+IMAGE_FSTYPES = "vfat"
+
+RPI_EEPROM:raspberrypi4-64 = "bootloader-2711/default/pieeprom-2023-01-11.bin"
+RPI_RECOVERY:raspberrypi4-64 = "bootloader-2711/default/recovery.bin"
+BOOT_CONF:raspberrypi4-64 = "boot4.conf"
+RPI_EEPROM:raspberrypi5 = "bootloader-2712/latest/pieeprom-2025-01-22.bin"
+RPI_RECOVERY:raspberrypi5 = "bootloader-2712/latest/recovery.bin"
+BOOT_CONF:raspberrypi5 = "boot5.conf"
+
+prepare_eeprom () {
+  cp "${RECIPE_SYSROOT_NATIVE}/usr/lib/firmware/raspberrypi/${RPI_EEPROM}" "${B}/pieeprom.bin"
+}
+
+do_rootfs () {
+  prepare_eeprom
+
+  # extract first certificate in secure boot cert chain
+  openssl x509 -in "${SECURE_BOOT_SIG_CERT}" > "${B}/secure_boot.cert"
+
+  cp "${THISDIR}/${PN}/${BOOT_CONF}" "${B}/boot.conf"
+
+  # update_eeprom
+  rpi-eeprom-digest \
+        -i "${B}/boot.conf" \
+        -o "${B}/boot.conf.sig" \
+        -k "${SECURE_BOOT_SIG_KEY}"
+
+  rpi-eeprom-config \
+        --config "${B}/boot.conf" \
+        --out "${IMAGE_ROOTFS}/pieeprom.bin" \
+        -d "${B}/boot.conf.sig" \
+        -p "${B}/secure_boot.cert" \
+        "${B}/pieeprom.bin"
+
+  # image_digest
+  rpi-eeprom-digest \
+        -i "${IMAGE_ROOTFS}/pieeprom.bin" \
+        -o "${IMAGE_ROOTFS}/pieeprom.sig"
+
+  cp "${RECIPE_SYSROOT_NATIVE}/usr/lib/firmware/raspberrypi/${RPI_RECOVERY}" "${IMAGE_ROOTFS}/"
+}
+ROOTFS_PREPROCESS_COMMAND += "return;"
+
+# backported from scarthgap
+oe_mkvfatfs () {
+    mkfs.vfat $@ -C ${IMGDEPLOYDIR}/${IMAGE_NAME}.vfat ${ROOTFS_SIZE}
+    mcopy -i "${IMGDEPLOYDIR}/${IMAGE_NAME}.vfat" -vsmpQ ${IMAGE_ROOTFS}/* ::/
+    ln -sf "${IMAGE_NAME}.vfat" "${IMGDEPLOYDIR}/${PN}-${MACHINE}.vfat"
+}
+IMAGE_CMD:vfat = "oe_mkvfatfs ${EXTRA_IMAGECMD}"

--- a/images/rpi-eeprom-secure-boot-image/boot4.conf
+++ b/images/rpi-eeprom-secure-boot-image/boot4.conf
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+[all]
+BOOT_UART=1
+WAKE_ON_GPIO=0
+POWER_OFF_ON_HALT=1
+HDMI_DELAY=0
+
+# Boot Order Codes, from https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#BOOT_ORDER
+# Try SD first (1), followed by, USB PCIe, NVMe PCIe, USB SoC XHCI then network
+BOOT_ORDER=0xf25641
+
+# Disable self-update mode
+ENABLE_SELF_UPDATE=0
+
+# Select signed-boot mode in the EEPROM. This can be used to during development
+# to test the signed boot image. Once secure boot is enabled via OTP this setting
+# has no effect i.e. it is always 1.
+SIGNED_BOOT=1

--- a/images/rpi-eeprom-secure-boot-image/boot5.conf
+++ b/images/rpi-eeprom-secure-boot-image/boot5.conf
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+[all]
+BOOT_UART=1
+POWER_OFF_ON_HALT=1
+HDMI_DELAY=0
+
+BOOT_ORDER=0xf2461
+
+# Disable self-update mode
+ENABLE_SELF_UPDATE=0
+
+# Select signed-boot mode in the EEPROM. This can be used to during development
+# to test the signed boot image. Once secure boot is enabled via OTP this setting
+# has no effect i.e. it is always 1.
+SIGNED_BOOT=1

--- a/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
+++ b/recipes-bsp/rpi-eeprom/rpi-eeprom_git.bb
@@ -1,0 +1,74 @@
+SUMMARY = "Installation scripts and binaries for the Raspberry Pi 4 EEPROM"
+DESCRIPTION = "This repository contains the rpi4 bootloader and scripts \
+for updating it in the spi eeprom"
+LICENSE = "BSD-3-Clause & Broadcom-RPi & MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=449418bd5e2b674b51a36c78f3f85a01"
+
+SRC_URI = " \
+    git://github.com/raspberrypi/rpi-eeprom.git;protocol=https;branch=master \
+"
+
+SRCREV = "b67b21ddda8b6468090fcdc5034bb075344a8903"
+PV = "v2025.01.22-2712"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} += " \
+    coreutils \
+    python3 \
+    python3-pycryptodomex \
+    openssl \
+    vim \
+"
+
+RDEPENDS:${PN}:append:class-target = " pciutils"
+
+inherit python3native
+
+do_install() {
+    install -d ${D}${bindir}
+
+    # install executables
+    install -m 0755 ${S}/tools/vl805 ${D}${bindir}
+    install -m 0755 ${S}/rpi-eeprom-update ${D}${bindir}
+    install -m 0755 ${S}/rpi-eeprom-config ${D}${bindir}
+    install -m 0755 ${S}/rpi-eeprom-digest ${D}${bindir}
+    install -m 0755 ${S}/tools/rpi-sign-bootcode ${D}${bindir}
+
+    # copy firmware files
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/default
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/latest
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/default
+    install -d ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/latest
+
+    install -m 644 ${S}/firmware-2711/default/* ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/default
+    install -m 644 ${S}/firmware-2711/latest/* ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/latest
+    install -m 644 ${S}/firmware-2712/default/* ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/default
+    install -m 644 ${S}/firmware-2712/latest/* ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/latest
+
+    ln -s default ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/critical
+    ln -s latest ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/stable
+    ln -s latest ${D}${base_libdir}/firmware/raspberrypi/bootloader-2711/beta
+    ln -s default ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/critical
+    ln -s latest ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/stable
+    ln -s latest ${D}${base_libdir}/firmware/raspberrypi/bootloader-2712/beta
+
+    # copy default config
+    install -d ${D}${sysconfdir}/default
+    install -D ${S}/rpi-eeprom-update-default ${D}${sysconfdir}/default/rpi-eeprom-update
+}
+
+FILES:${PN} += "${base_libdir}/firmware/raspberrypi/bootloader-*"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
+# vl805 tool sources are not available (yet), as it comes as a precompiled
+# binary only. It has ARM architecture whereas target machine is Aarch64. We
+# need to disable arch check for it otherwise it cannot packed.
+QAPATHTEST[arch] = ""
+
+COMPATIBLE_MACHINE = "raspberrypi4|raspberrypi4-64|raspberrypi5"
+
+BBCLASSEXTEND = "native"
+COMPATIBLE_MACHINE:class-native = ".*"

--- a/scripts/lib/wic/plugins/source/bootimg-partition-rpi-sb.py
+++ b/scripts/lib/wic/plugins/source/bootimg-partition-rpi-sb.py
@@ -1,0 +1,217 @@
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# DESCRIPTION
+# This implements the 'bootimg-partition' source plugin class for
+# 'wic'. The plugin creates an image of boot partition, copying over
+# files listed in IMAGE_BOOT_FILES bitbake variable.
+#
+# AUTHORS
+# Maciej Borzecki <maciej.borzecki (at] open-rnd.pl>
+#
+
+import logging
+import os
+import re
+import tempfile
+
+from glob import glob
+
+from wic import WicError
+from wic.engine import get_custom_config
+from wic.pluginbase import SourcePlugin
+from wic.misc import exec_cmd, exec_native_cmd, get_bitbake_var
+
+logger = logging.getLogger('wic')
+
+class BootimgPartitionRPiSBPlugin(SourcePlugin):
+    """
+    Create an image of boot partition, copying over files
+    listed in IMAGE_BOOT_FILES bitbake variable.
+    """
+
+    name = 'bootimg-partition-rpi-sb'
+
+    @classmethod
+    def do_configure_partition(cls, part, source_params, cr, cr_workdir,
+                             oe_builddir, bootimg_dir, kernel_dir,
+                             native_sysroot):
+        """
+        Called before do_prepare_partition(), create u-boot specific boot config
+        """
+        hdddir = "%s/boot.%d" % (cr_workdir, part.lineno)
+        install_cmd = "install -d %s" % hdddir
+        exec_cmd(install_cmd)
+
+        if not kernel_dir:
+            kernel_dir = get_bitbake_var("DEPLOY_DIR_IMAGE")
+            if not kernel_dir:
+                raise WicError("Couldn't find DEPLOY_DIR_IMAGE, exiting")
+
+        boot_files = None
+        for (fmt, id) in (("_uuid-%s", part.uuid), ("_label-%s", part.label), (None, None)):
+            if fmt:
+                var = fmt % id
+            else:
+                var = ""
+
+            boot_files = get_bitbake_var("IMAGE_BOOT_FILES" + var)
+            if boot_files is not None:
+                break
+
+        if boot_files is None:
+            raise WicError('No boot files defined, IMAGE_BOOT_FILES unset for entry #%d' % part.lineno)
+
+        logger.debug('Boot files: %s', boot_files)
+
+        # list of tuples (src_name, dst_name)
+        deploy_files = []
+        for src_entry in re.findall(r'[\w;\-\./\*]+', boot_files):
+            if ';' in src_entry:
+                dst_entry = tuple(src_entry.split(';'))
+                if not dst_entry[0] or not dst_entry[1]:
+                    raise WicError('Malformed boot file entry: %s' % src_entry)
+            else:
+                dst_entry = (src_entry, src_entry)
+
+            logger.debug('Destination entry: %r', dst_entry)
+            deploy_files.append(dst_entry)
+
+        cls.install_task = [];
+        for deploy_entry in deploy_files:
+            src, dst = deploy_entry
+            if '*' in src:
+                # by default install files under their basename
+                entry_name_fn = os.path.basename
+                if dst != src:
+                    # unless a target name was given, then treat name
+                    # as a directory and append a basename
+                    entry_name_fn = lambda name: \
+                                    os.path.join(dst,
+                                                 os.path.basename(name))
+
+                srcs = glob(os.path.join(kernel_dir, src))
+
+                logger.debug('Globbed sources: %s', ', '.join(srcs))
+                for entry in srcs:
+                    src = os.path.relpath(entry, kernel_dir)
+                    entry_dst_name = entry_name_fn(entry)
+                    cls.install_task.append((src, entry_dst_name))
+            else:
+                cls.install_task.append((src, dst))
+
+        if source_params.get('loader') != "u-boot":
+            return
+
+        configfile = cr.ks.bootloader.configfile
+        custom_cfg = None
+        if configfile:
+            custom_cfg = get_custom_config(configfile)
+            if custom_cfg:
+                # Use a custom configuration for extlinux.conf
+                extlinux_conf = custom_cfg
+                logger.debug("Using custom configuration file "
+                             "%s for extlinux.cfg", configfile)
+            else:
+                raise WicError("configfile is specified but failed to "
+                               "get it from %s." % configfile)
+
+        if not custom_cfg:
+            # The kernel types supported by the sysboot of u-boot
+            kernel_types = ["zImage", "Image", "fitImage", "uImage", "vmlinux"]
+            has_dtb = False
+            fdt_dir = '/'
+            kernel_name = None
+
+            # Find the kernel image name, from the highest precedence to lowest
+            for image in kernel_types:
+                for task in cls.install_task:
+                    src, dst = task
+                    if re.match(image, src):
+                        kernel_name = os.path.join('/', dst)
+                        break
+                if kernel_name:
+                    break
+
+            for task in cls.install_task:
+                src, dst = task
+                # We suppose that all the dtb are in the same directory
+                if re.search(r'\.dtb', src) and fdt_dir == '/':
+                    has_dtb = True
+                    fdt_dir = os.path.join(fdt_dir, os.path.dirname(dst))
+                    break
+
+            if not kernel_name:
+                raise WicError('No kernel file found')
+
+            # Compose the extlinux.conf
+            extlinux_conf = "default Yocto\n"
+            extlinux_conf += "label Yocto\n"
+            extlinux_conf += "   kernel %s\n" % kernel_name
+            if has_dtb:
+                extlinux_conf += "   fdtdir %s\n" % fdt_dir
+            bootloader = cr.ks.bootloader
+            extlinux_conf += "append root=%s rootwait %s\n" \
+                             % (cr.rootdev, bootloader.append if bootloader.append else '')
+
+        install_cmd = "install -d %s/extlinux/" % hdddir
+        exec_cmd(install_cmd)
+        cfg = open("%s/extlinux/extlinux.conf" % hdddir, "w")
+        cfg.write(extlinux_conf)
+        cfg.close()
+
+
+    @classmethod
+    def do_prepare_partition(cls, part, source_params, cr, cr_workdir,
+                             oe_builddir, bootimg_dir, kernel_dir,
+                             rootfs_dir, native_sysroot):
+        """
+        Called to do the actual content population for a partition i.e. it
+        'prepares' the partition to be incorporated into the image.
+        In this case, does the following:
+        - sets up a vfat partition
+        - copies all files listed in IMAGE_BOOT_FILES variable
+        """
+        hdddir = "%s/boot.%d" % (cr_workdir, part.lineno)
+
+        if not kernel_dir:
+            kernel_dir = get_bitbake_var("DEPLOY_DIR_IMAGE")
+            if not kernel_dir:
+                raise WicError("Couldn't find DEPLOY_DIR_IMAGE, exiting")
+
+        logger.debug('Kernel dir: %s', bootimg_dir)
+
+        logger.debug("%s %s" % (kernel_dir, hdddir))
+
+        # create boot.img
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            for task in cls.install_task:
+                src_path, dst_path = task
+                logger.debug('Install %s as %s', src_path, dst_path)
+                install_cmd = "install -m 0644 -D %s %s" \
+                              % (os.path.join(kernel_dir, src_path),
+                                 os.path.join(tmp_dir, dst_path))
+                exec_cmd(install_cmd)
+
+            boot_img = os.path.join(hdddir, "boot.img")
+
+            boot_img_cmd = "mkfs.vfat -n BOOTIMG -S 512 -C %s %d" % (boot_img, 180*1024)
+            exec_cmd(boot_img_cmd)
+
+            mcopy_cmd = "mcopy -i %s -s %s/* ::/" % (boot_img, tmp_dir)
+            exec_cmd(mcopy_cmd, native_sysroot)
+
+        # create boot.sig
+        boot_sig = os.path.join(hdddir, "boot.sig")
+        secure_boot_sig_key = get_bitbake_var("SECURE_BOOT_SIG_KEY")
+        if not secure_boot_sig_key:
+            raise WicError("Couldn't find SECURE_BOOT_SIG_KEY, exiting")
+        logger.debug(secure_boot_sig_key)
+
+        sign_cmd = "rpi-eeprom-digest -i %s -o %s -k %s" \
+                   % (boot_img, boot_sig, secure_boot_sig_key)
+        exec_native_cmd(sign_cmd, native_sysroot)
+
+        logger.debug('Prepare boot partition using rootfs in %s', hdddir)
+        part.prepare_rootfs(cr_workdir, oe_builddir, hdddir,
+                            native_sysroot, False)

--- a/wic/gyroidos-cml.raspberrypi.wks.in
+++ b/wic/gyroidos-cml.raspberrypi.wks.in
@@ -1,4 +1,4 @@
-part /boot --source bootimg-partition --fstype=${GYROIDOS_BOOTPART_FS} --label boot --active --align 4096 --fixed-size ${GYROIDOS_BOOTPART_SIZE}M
+part /boot --source ${RPI_WIC_BOOT_PLUGIN} --fstype=${GYROIDOS_BOOTPART_FS} --label boot --active --align 4096 --fixed-size ${GYROIDOS_BOOTPART_SIZE}M
 part / --source rootfs  --fstype=${GYROIDOS_DATAPART_FS} --label gyroidos --align ${GYROIDOS_TARGET_ALIGN} --extra-space ${GYROIDOS_DATAPART_EXTRA_SPACE}M
 
 bootloader --ptable ${GYROIDOS_PARTTABLE_TYPE}


### PR DESCRIPTION
This PR adds:

- Config for RPi5 and RPi 500
- a wic plugin to build a Rpi boot partition packed into a boot.img fat partition (signed for secure boot using ssig_subca.key)
- secure boot configs
- some features removed from trustx-cml-initramfs to save space (see commit for reason)
- a helper script that reprograms a Pi's eeprom with the public key from ssig_subca.cert for secure boot.